### PR TITLE
Removed the redundant dot from the stylesheet, again

### DIFF
--- a/src/org/vaadin/hene/popupbutton/widgetset/public/popupbutton/popupbutton.css
+++ b/src/org/vaadin/hene/popupbutton/widgetset/public/popupbutton/popupbutton.css
@@ -1,4 +1,4 @@
-.v-popupbutton. .v-button-wrap * {
+.v-popupbutton .v-button-wrap * {
 	float: left;
 }	
 


### PR DESCRIPTION
The last pull request I made was integrated to the branch 2.3, but not in 2.4 (I'm currently using PopupButton 2.4.1). So here it is again for branch 2.4.
