### PR TITLE
Workaround for an uncaught TypeError #24

### DIFF
--- a/addon/src/main/java/org/vaadin/hene/popupbutton/widgetset/client/ui/VPopupButton.java
+++ b/addon/src/main/java/org/vaadin/hene/popupbutton/widgetset/client/ui/VPopupButton.java
@@ -290,9 +290,13 @@ public class VPopupButton extends VButton {
 
         if (isOverlay) {
             while (element != null) {
-                if (element.getClassName().contains("v-window")) {
-                    return false;
+                try {
+                    if (element.getClassName().contains("v-window")) {
+                        return false;
+                    }
                 }
+                catch(Exception e)
+                {}
                 element = element.getParentElement();
             }
             return true;


### PR DESCRIPTION
Workaround for an uncaught clientside TypeError exception #24 that is thrown from GWT's java.lang.String when clicking on SVG image elements and having a PopupButton somewhere in the UI.
